### PR TITLE
fix(ci): use positional argument for pod name in bigpods-release.yml

### DIFF
--- a/.github/workflows/bigpods-release.yml
+++ b/.github/workflows/bigpods-release.yml
@@ -240,11 +240,11 @@ jobs:
 
           # Build with comprehensive tags
           ./build-bigpods.sh \
-            --pod ${{ matrix.pod }} \
             --version "$version" \
             --no-cache \
             --push \
-            --verbose
+            --verbose \
+            ${{ matrix.pod }}
 
       - name: 🏷️ Tag Additional Versions
         run: |


### PR DESCRIPTION
## Summary
- `build-bigpods.sh` ne supporte pas l'option `--pod`, le pod name se passe en argument positionnel
- Le workflow `bigpods-release.yml` utilisait `--pod business` → `❌ Unknown option: --pod`
- Fix : déplacer `${{ matrix.pod }}` en argument positionnel à la fin de la commande

## Test plan
- [ ] Vérifier que le workflow `bigpods-release.yml` passe au prochain tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)