### PR TITLE
feat(DR-579): add NGINX /panorama/ location for panorama SPA

### DIFF
--- a/docker/bigpods/experience-pod/nginx.prod.conf
+++ b/docker/bigpods/experience-pod/nginx.prod.conf
@@ -72,7 +72,20 @@ http {
             add_header Cache-Control "public, immutable";
         }
 
-        # Panorama Service routes
+        # Panorama SPA (VR fallback & 2D gallery) — DR-579
+        location /panorama/ {
+            rewrite ^/panorama/(.*) /$1 break;
+            rewrite ^/panorama$ / break;
+
+            proxy_pass http://panorama_service;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Panorama Service API routes
         location /api/panorama {
             proxy_pass http://panorama_service;
             proxy_http_version 1.1;

--- a/docker/bigpods/experience-pod/nginx/experience-pod.conf
+++ b/docker/bigpods/experience-pod/nginx/experience-pod.conf
@@ -97,6 +97,28 @@ server {
     }
 
     # ========================================
+    # Panorama SPA (VR fallback & 2D gallery)
+    # DR-579: Serve panorama React app under /panorama/
+    # ========================================
+
+    location /panorama/ {
+        # Strip /panorama/ prefix and proxy to panorama Node.js service
+        rewrite ^/panorama/(.*) /$1 break;
+        rewrite ^/panorama$ / break;
+
+        proxy_pass http://panorama_service;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 30s;
+        proxy_read_timeout 60s;
+    }
+
+    # ========================================
     # API Proxy - Gateway Service
     # ========================================
     


### PR DESCRIPTION
## Summary
- Add `location /panorama/` block in `experience-pod.conf` and `nginx.prod.conf`
- Strips `/panorama/` prefix and proxies to `panorama_service` (port 3006)
- Enables panorama React app to be served under same domain in production

## Files changed
- `docker/bigpods/experience-pod/nginx/experience-pod.conf`
- `docker/bigpods/experience-pod/nginx.prod.conf`

## Test plan
- [ ] NGINX config syntax validation (`nginx -t`)
- [ ] `/panorama/?destination=paris&mode=gallery` proxies to panorama service

🤖 Generated with [Claude Code](https://claude.com/claude-code)