### PR TITLE
feat(experience-pod): build and serve Panorama VR React app (DR-574)

### DIFF
--- a/docker/bigpods/experience-pod/Dockerfile.prod
+++ b/docker/bigpods/experience-pod/Dockerfile.prod
@@ -1,7 +1,7 @@
 # ============================================================================
 # DreamScape Experience Pod - Production Dockerfile
-# Multi-process container: Web Client + Panorama (stub) + Gateway (stub)
-# Architecture: React build + NGINX static serving + Node.js services
+# Multi-process container: Web Client + Panorama + Gateway
+# Architecture: React builds + NGINX static serving + Node.js services
 # ============================================================================
 
 # =============================================================================
@@ -29,7 +29,24 @@ ENV NODE_ENV=production
 RUN npm run build -- --mode ${BUILD_MODE}
 
 # =============================================================================
-# Stage 2: Production Image
+# Stage 2: Build Panorama VR App (React/CRA + Three.js)
+# =============================================================================
+FROM node:20-alpine AS panorama-builder
+
+WORKDIR /build/panorama
+
+COPY dreamscape-frontend/panorama/package*.json ./
+RUN npm install --ignore-scripts && npm cache clean --force
+
+COPY dreamscape-frontend/panorama ./
+
+ENV NODE_ENV=production
+ENV PUBLIC_URL=/panorama
+
+RUN npm run build
+
+# =============================================================================
+# Stage 3: Production Image
 # =============================================================================
 FROM node:20-alpine AS production
 
@@ -69,7 +86,10 @@ RUN chown -R nodejs:nodejs /app && \
 # Copy built web client to nginx serve directory
 COPY --from=web-builder --chown=nginx:nginx /build/web/dist /usr/share/nginx/html
 
-# Copy Panorama service (JavaScript stub from bigpods)
+# Copy built Panorama VR app to nginx serve directory (served at /panorama/)
+COPY --from=panorama-builder --chown=nginx:nginx /build/panorama/build /usr/share/nginx/html/panorama
+
+# Copy Panorama API service (VR catalog/metadata endpoints)
 COPY --chown=nodejs:nodejs dreamscape-infra/docker/bigpods/experience-pod/services/panorama-service/ /app/panorama/
 
 # Copy Gateway service (JavaScript stub from bigpods)
@@ -120,6 +140,6 @@ CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]
 # Metadata labels
 LABEL maintainer="DreamScape Team <dev@dreamscape.com>" \
       version="1.0.0" \
-      description="DreamScape Experience Pod - Web Client + Gateway + Panorama (stubs)" \
+      description="DreamScape Experience Pod - Web Client + Panorama VR + Gateway" \
       org.opencontainers.image.title="DreamScape Experience Pod" \
       org.opencontainers.image.vendor="DreamScape"

--- a/docker/bigpods/experience-pod/nginx.prod.conf
+++ b/docker/bigpods/experience-pod/nginx.prod.conf
@@ -72,17 +72,16 @@ http {
             add_header Cache-Control "public, immutable";
         }
 
-        # Panorama SPA (VR fallback & 2D gallery) — DR-579
+        # Panorama SPA (VR + 2D gallery) — DR-574 / DR-579
+        # Serves the built React/Three.js app as static files
         location /panorama/ {
-            rewrite ^/panorama/(.*) /$1 break;
-            rewrite ^/panorama$ / break;
+            alias /usr/share/nginx/html/panorama/;
+            try_files $uri $uri/ /panorama/index.html;
 
-            proxy_pass http://panorama_service;
-            proxy_http_version 1.1;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
+            # CORS headers for VR headset access
+            add_header Access-Control-Allow-Origin * always;
+            add_header Access-Control-Allow-Methods "GET, OPTIONS" always;
+            add_header Access-Control-Allow-Headers "Authorization, Content-Type" always;
         }
 
         # Panorama Service API routes


### PR DESCRIPTION
## Summary
- Add `panorama-builder` Docker stage to build the React/Three.js VR app from `dreamscape-frontend/panorama/`
- Copy built panorama SPA to `/usr/share/nginx/html/panorama/` in the experience-pod image
- Update NGINX to serve `/panorama/` as static files with `try_files` SPA fallback (instead of proxying to the Node.js stub)
- Keep panorama-service Node.js stub for API endpoints (`/api/panorama/*`)

This enables the VR PIN entry screen at `/panorama/?pin=XXXXXX` to actually load the React app instead of returning 404.

## Test plan
- [ ] Verify Docker image builds successfully with panorama stage
- [ ] Verify `http://79.72.27.180/panorama/` loads the VR React app
- [ ] Verify `http://79.72.27.180/panorama/?pin=XXXXXX` shows the PIN entry screen
- [ ] Verify VR Access button → PIN generation → panorama redirect works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)