### PR TITLE
fix(nginx): add panorama VR asset paths (DR-574)

### DIFF
--- a/docker/bigpods/experience-pod/nginx.prod.conf
+++ b/docker/bigpods/experience-pod/nginx.prod.conf
@@ -84,6 +84,21 @@ http {
             add_header Access-Control-Allow-Headers "Authorization, Content-Type" always;
         }
 
+        # Panorama assets redirect — images referenced as /panoramas/* in the VR app
+        # need to be served from /panorama/panoramas/* (the built CRA output)
+        location /panoramas/ {
+            alias /usr/share/nginx/html/panorama/panoramas/;
+            expires 1h;
+            add_header Cache-Control "public, immutable";
+        }
+
+        # Panorama audio assets
+        location /audio/ {
+            alias /usr/share/nginx/html/panorama/audio/;
+            expires 1h;
+            add_header Cache-Control "public, immutable";
+        }
+
         # Panorama Service API routes
         location /api/panorama {
             proxy_pass http://panorama_service;


### PR DESCRIPTION
## Summary
- Add NGINX aliases for `/panoramas/` and `/audio/` to serve VR assets from the panorama CRA build
- The VR app references images as `/panoramas/paris/eiffel-tower.jpg` but the built app is at `/panorama/panoramas/...`

## Test plan
- [ ] Verify panorama images load at `/panorama/?destination=par&autoVR=true`
- [ ] Verify 360° VR scene renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)