### PR TITLE
docs: create READMEs for k8s, terraform, monitoring and cicd

### DIFF
--- a/cicd/README.md
+++ b/cicd/README.md
@@ -1,0 +1,134 @@
+# CI/CD — Pipelines DreamScape
+
+> **Pipelines GitHub Actions** — Intégration et déploiement continus en architecture 2 stages
+
+## Architecture en 2 stages
+
+DreamScape utilise un pattern de **repository dispatch** entre deux dépôts :
+
+```
+dreamscape-services (Stage 1)        dreamscape-infra (Stage 2)
+      │                                       │
+      │  push/PR → ci-trigger.yml             │
+      │  → détecte services modifiés          │
+      │  → émet repository_dispatch ──────────►│
+      │                                       │  unified-cicd.yml
+      │                                       │  → Clone source repo
+      │                                       │  → Tests
+      │                                       │  → Build Docker
+      │                                       │  → Push GHCR
+      │                                       │  → Deploy k3s
+```
+
+## Workflows
+
+### Stage 1 — `dreamscape-services` (source)
+
+**Fichier** : `.github/workflows/ci-trigger.yml`
+
+**Déclencheurs** : Push sur `main`, `dev`, `develop`, `feature/**` + Pull Requests
+
+**Actions** :
+1. Détecte les services modifiés (auth, user, voyage, payment, ai, panorama)
+2. Si `db/` ou `shared/` modifiés → rebuild de **tous** les services
+3. Lint les services modifiés
+4. Émet un `repository_dispatch` vers `dreamscape-infra` avec :
+   ```json
+   {
+     "event_type": "services-changed",
+     "client_payload": {
+       "source_repo": "dreamscape-services",
+       "ref": "main",
+       "sha": "abc123",
+       "component": "auth,user"
+     }
+   }
+   ```
+
+### Stage 2 — `dreamscape-infra` (déploiement)
+
+**Fichiers** :
+| Workflow | Description |
+|----------|-------------|
+| `workflows/ci.yml` | Pipeline CI principal |
+| `workflows/bigpods-ci.yml` | CI spécifique Big Pods |
+| `workflows/bigpods-cd.yml` | CD (déploiement) Big Pods |
+| `workflows/bigpods-release.yml` | Release Big Pods |
+
+**Actions** (unified-cicd.yml) :
+1. Parse le payload `repository_dispatch`
+2. Clone le repo source (`dreamscape-services`)
+3. Exécute les tests
+4. Build les images Docker (multi-stage)
+5. Push vers GHCR (`ghcr.io/dreamscape-ai/<service>:latest`)
+6. Déploie sur k3s via `kubectl apply -k k8s/overlays/<env>`
+7. Crée un GitHub Deployment avec statut automatique
+
+## Mapping branches → environnements
+
+| Branche | Environnement | Action |
+|---------|---------------|--------|
+| `main` | production | Deploy prod |
+| `develop` | staging | Deploy staging |
+| `feature/**`, `bugfix/**`, `hotfix/**` | dev | Deploy dev |
+| Pull Requests | dev | Deploy preview |
+
+## Images Docker
+
+Format des tags :
+```
+ghcr.io/dreamscape-ai/<service>:<sha>
+ghcr.io/dreamscape-ai/<service>:latest
+ghcr.io/dreamscape-ai/<service>:v1.2.3
+```
+
+Registry : GitHub Container Registry (GHCR)
+
+## Big Pods CI/CD
+
+Le workflow Big Pods est distinct car il gère les containers multi-services :
+
+```bash
+# bigpods-ci.yml — Tests
+# 1. Build Core Pod (auth + user + nginx)
+# 2. Test tous les endpoints
+# 3. Vérification health checks
+
+# bigpods-cd.yml — Déploiement
+# 1. Build et push l'image Core Pod
+# 2. kubectl apply bigpods-production-bootstrap.yaml
+# 3. Vérification post-déploiement
+```
+
+## Secrets requis
+
+| Secret | Description |
+|--------|-------------|
+| `GHCR_TOKEN` | Token GitHub pour push GHCR |
+| `KUBE_CONFIG` | Kubeconfig k3s (base64) |
+| `DISPATCH_TOKEN` | Token pour repository_dispatch |
+| `SLACK_WEBHOOK` | Notifications Slack (optionnel) |
+
+## Stratégies de déploiement
+
+- **Rolling Update** — Déploiement par défaut (zero-downtime)
+- **Blue-Green** — Pour les changements breaking (configuré manuellement)
+- **Canary** — Pour les features à risque (10% → 50% → 100%)
+- **Rollback automatique** — Si les health checks échouent post-déploiement
+
+## Détection des services modifiés
+
+Le workflow analyse le `git diff` pour détecter les changements :
+
+```yaml
+# Logique de détection
+if: contains(steps.changes.outputs.files, 'auth/')
+  → rebuild auth-service
+
+if: contains(steps.changes.outputs.files, 'db/') || contains(steps.changes.outputs.files, 'shared/')
+  → rebuild ALL services (shared dependency)
+```
+
+---
+
+*Voir `dreamscape-infra/README.md` pour l'architecture globale.*

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,162 @@
+# Kubernetes — Manifests DreamScape
+
+> **Orchestration K8s** — Déploiements, services, HPA et configurations par environnement (k3s)
+
+## Structure
+
+```
+k8s/
+├── base/                          # Configurations de base (partagées)
+│   ├── auth/
+│   │   ├── deployment.yaml        # Deployment auth-service
+│   │   ├── service.yaml
+│   │   ├── configmap.yaml
+│   │   ├── hpa.yaml               # Horizontal Pod Autoscaler
+│   │   ├── networkpolicy.yaml
+│   │   └── poddisruptionbudget.yaml
+│   ├── user/
+│   ├── voyage/
+│   ├── gateway/
+│   │   ├── deployment.yaml
+│   │   ├── service.yaml
+│   │   ├── ingress.yaml
+│   │   ├── hpa.yaml
+│   │   └── networkpolicy.yaml
+│   ├── redis/
+│   │   ├── deployment.yaml
+│   │   ├── service.yaml
+│   │   ├── pvc.yaml               # PersistentVolumeClaim
+│   │   └── configmap.yaml
+│   └── common/
+│       ├── cert-issuer.yaml       # Let's Encrypt cert-manager
+│       └── networkpolicy.yaml
+├── overlays/                      # Surcharges par environnement
+│   ├── dev/
+│   │   └── kustomization.yaml
+│   ├── staging/
+│   │   └── kustomization.yaml
+│   └── prod/
+│       └── kustomization.yaml
+├── bigpods-production-bootstrap.yaml   # Bootstrap Big Pods prod
+└── bigpods-staging-bootstrap.yaml      # Bootstrap Big Pods staging
+```
+
+## Déploiement par environnement
+
+```bash
+# Développement
+kubectl apply -k k8s/overlays/dev
+
+# Staging
+kubectl apply -k k8s/overlays/staging
+
+# Production
+kubectl apply -k k8s/overlays/prod
+```
+
+## Commandes utiles
+
+```bash
+# Vérifier les pods
+kubectl get pods -n dreamscape
+
+# Logs d'un service
+kubectl logs -f deployment/auth-service -n dreamscape
+
+# Rolling update
+kubectl rollout restart deployment/auth-service -n dreamscape
+
+# Vérifier le statut du déploiement
+kubectl rollout status deployment/auth-service -n dreamscape
+
+# Scaling manuel
+kubectl scale deployment/auth-service --replicas=3 -n dreamscape
+
+# Port forwarding (développement)
+kubectl port-forward service/gateway 4000:3000 -n dreamscape
+kubectl port-forward service/auth-service 3001:3001 -n dreamscape
+```
+
+## Namespaces
+
+```bash
+kubectl create namespace dreamscape-dev
+kubectl create namespace dreamscape-staging
+kubectl create namespace dreamscape-prod
+```
+
+## Horizontal Pod Autoscaler (HPA)
+
+Les services `auth` et `gateway` ont un HPA configuré :
+
+```yaml
+spec:
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 70
+```
+
+## Kustomize
+
+Les overlays utilisent Kustomize pour surcharger les bases :
+
+```yaml
+# overlays/prod/kustomization.yaml
+resources:
+  - ../../base/auth
+  - ../../base/user
+  - ../../base/voyage
+  - ../../base/gateway
+  - ../../base/redis
+
+images:
+  - name: ghcr.io/dreamscape-ai/auth-service
+    newTag: latest
+
+patches:
+  - path: replicas.yaml   # Surcharge du nombre de replicas
+```
+
+## Big Pods Bootstrap
+
+Pour les déploiements Big Pods (Core Pod + Business Pod), utiliser les fichiers dédiés :
+
+```bash
+# Production
+kubectl apply -f k8s/bigpods-production-bootstrap.yaml
+
+# Staging
+kubectl apply -f k8s/bigpods-staging-bootstrap.yaml
+```
+
+Ces fichiers déploient les containers multi-services avec Supervisor + NGINX.
+
+## Images Docker
+
+Toutes les images sont publiées sur GitHub Container Registry :
+
+```
+ghcr.io/dreamscape-ai/auth-service:latest
+ghcr.io/dreamscape-ai/user-service:latest
+ghcr.io/dreamscape-ai/voyage-service:latest
+ghcr.io/dreamscape-ai/payment-service:latest
+ghcr.io/dreamscape-ai/ai-service:latest
+ghcr.io/dreamscape-ai/gateway:latest
+```
+
+## Network Policies
+
+Les `NetworkPolicy` limitent la communication entre pods :
+- Seul le Gateway peut contacter les services backend
+- Les services peuvent contacter PostgreSQL et Redis
+- Les communications cross-namespace sont bloquées
+
+---
+
+*Voir `dreamscape-infra/README.md` pour l'architecture Big Pods complète.*

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,152 @@
+# Monitoring — Observabilité DreamScape
+
+> **Stack d'observabilité** — Prometheus, Grafana, Alertmanager, Loki et Promtail
+
+## Stack
+
+| Outil | Rôle | Port |
+|-------|------|------|
+| Prometheus | Collecte et stockage des métriques | 9090 |
+| Grafana | Dashboards et visualisation | 3000 |
+| Alertmanager | Gestion et routage des alertes | 9093 |
+| Loki | Agrégation des logs | 3100 |
+| Promtail | Agent de collecte de logs | — |
+| kafka-jmx | Métriques JMX Kafka | — |
+
+## Structure
+
+```
+monitoring/
+├── prometheus.yml                    # Config principale Prometheus
+├── alertmanager.yml                  # Config Alertmanager (routing, receivers)
+├── loki.yml                          # Config Loki (logs)
+├── promtail.yml                      # Config Promtail (agent logs)
+├── kafka-jmx-config.yml              # Métriques JMX Kafka
+├── requirements.txt                  # Dépendances Python (scripts)
+├── MONITORING_WORKFLOW_PROCEDURES.md # Procédures opérationnelles
+├── database-migration-monitor.py     # Monitoring migrations DB
+├── dreamscape-repository-monitor.sh  # Monitoring des repos
+├── prometheus/
+│   ├── alerts.yaml                   # Règles d'alerte principales
+│   ├── alerts-availability.yaml      # Alertes disponibilité
+│   ├── health-probes.yaml            # Sondes de santé
+│   ├── recording-rules-sla.yaml      # Règles SLA
+│   └── values.yaml
+├── grafana/
+│   ├── datasources.yml               # Sources de données Grafana
+│   ├── dashboard-overview.json       # Dashboard vue d'ensemble
+│   ├── dashboard-availability.json   # Dashboard disponibilité
+│   └── dashboards/
+│       └── kafka-monitoring.json     # Dashboard Kafka
+├── config/
+│   └── monitoring-config.json
+└── rules/
+    └── kafka-alerts.yaml             # Règles d'alerte Kafka
+```
+
+## Cibles Prometheus
+
+Les services DreamScape exposent leurs métriques sur `/metrics` :
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: 'dreamscape-services'
+    static_configs:
+      - targets:
+        - 'auth-service:3001'
+        - 'user-service:3002'
+        - 'voyage-service:3003'
+        - 'payment-service:3004'
+        - 'ai-service:3005'
+        - 'gateway:4000'
+    metrics_path: /metrics
+    scrape_interval: 15s
+```
+
+## Dashboards Grafana
+
+| Dashboard | Description |
+|-----------|-------------|
+| `dashboard-overview.json` | Vue globale : latences, taux d'erreur, throughput |
+| `dashboard-availability.json` | Disponibilité et SLA par service |
+| `kafka-monitoring.json` | Topics Kafka, lag consommateurs, throughput |
+
+### Importer les dashboards
+
+```bash
+# Via l'API Grafana
+curl -X POST http://localhost:3000/api/dashboards/import \
+  -H "Content-Type: application/json" \
+  -d @grafana/dashboard-overview.json
+```
+
+## Alertes
+
+### Alertes critiques
+| Alerte | Condition | Sévérité |
+|--------|-----------|----------|
+| `HighErrorRate` | Taux erreur 5xx > 10% sur 5min | critical |
+| `ServiceDown` | Service health check KO | critical |
+| `DatabaseConnectionFailed` | Connexion DB perdue | critical |
+| `KafkaLagHigh` | Lag consommateur > 1000 messages | warning |
+
+### Alertes SLA
+| Alerte | Condition |
+|--------|-----------|
+| `SLABreach` | Disponibilité < 99.9% sur 1h |
+| `LatencyP99High` | P99 > 500ms sur 10min |
+
+## Alertmanager
+
+```yaml
+# alertmanager.yml — Configuration de routing
+route:
+  group_by: ['alertname', 'service']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 12h
+  receiver: 'team-slack'
+
+receivers:
+  - name: 'team-slack'
+    slack_configs:
+      - channel: '#alerts-dreamscape'
+        send_resolved: true
+```
+
+## Logs (Loki + Promtail)
+
+Promtail collecte les logs de tous les containers Docker et les envoie à Loki.
+
+```bash
+# Requête Loki pour les erreurs auth-service
+{app="auth-service"} |= "ERROR"
+
+# Logs payment webhook
+{app="payment-service"} |= "webhook" | json
+```
+
+## Démarrage local
+
+```bash
+# Depuis dreamscape-infra/
+docker-compose -f docker/docker-compose.monitoring.yml up -d
+
+# Accès
+# Grafana    : http://localhost:3000 (admin/admin)
+# Prometheus : http://localhost:9090
+# Alertmanager : http://localhost:9093
+```
+
+## Procédures opérationnelles
+
+Voir `MONITORING_WORKFLOW_PROCEDURES.md` pour les runbooks détaillés :
+- Procédure d'escalade lors d'alertes critiques
+- Investigation des pics de latence
+- Monitoring des migrations DB
+- Gestion des incidents Kafka
+
+---
+
+*Voir `dreamscape-infra/README.md` pour l'architecture globale.*

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,141 @@
+# Terraform — Infrastructure as Code DreamScape
+
+> **IaC** — Provisioning de l'infrastructure cloud pour les environnements DreamScape
+
+## Structure
+
+```
+terraform/
+├── modules/
+│   ├── k3s/                    # Cluster Kubernetes k3s
+│   │   ├── main.tf
+│   │   ├── variables.tf
+│   │   ├── outputs.tf
+│   │   ├── cloud-init-server.yaml   # Config serveur k3s
+│   │   └── cloud-init-agent.yaml    # Config agents k3s
+│   ├── databases/              # PostgreSQL, Redis
+│   │   └── main.tf
+│   └── networking/             # VPC, subnets, security groups
+│       ├── main.tf
+│       ├── variables.tf
+│       └── outputs.tf
+└── environments/               # Configurations par environnement
+    ├── dev/
+    ├── staging/
+    └── prod/
+```
+
+## Quick Start
+
+```bash
+# Prérequis
+terraform version   # >= 1.5
+aws configure       # ou équivalent selon cloud provider
+
+# Initialisation
+cd terraform
+terraform init
+
+# Planifier les changements
+terraform plan -var-file="environments/dev/terraform.tfvars"
+
+# Appliquer (dev)
+terraform apply -var-file="environments/dev/terraform.tfvars"
+
+# Détruire (attention !)
+terraform destroy -var-file="environments/dev/terraform.tfvars"
+```
+
+## Workspaces par environnement
+
+```bash
+# Créer les workspaces
+terraform workspace new dev
+terraform workspace new staging
+terraform workspace new prod
+
+# Changer de workspace
+terraform workspace select dev
+terraform workspace list
+```
+
+## Modules
+
+### Module `k3s`
+Provisionne un cluster k3s léger pour l'orchestration des containers DreamScape.
+
+**Variables clés** :
+```hcl
+variable "environment"    { default = "dev" }
+variable "region"         { default = "eu-west-1" }
+variable "instance_type"  { default = "t3.medium" }
+variable "node_count"     { default = 2 }
+```
+
+**Outputs** :
+- `cluster_endpoint` — URL du cluster k3s
+- `kubeconfig` — Fichier kubeconfig généré
+
+### Module `databases`
+Provisionne PostgreSQL managé et Redis.
+
+**Ressources créées** :
+- Instance PostgreSQL RDS (ou équivalent)
+- Cluster Redis ElastiCache (ou équivalent)
+- Security groups et subnet groups dédiés
+
+### Module `networking`
+VPC, subnets publics/privés, internet gateway, NAT gateway.
+
+**Variables clés** :
+```hcl
+variable "vpc_cidr"           { default = "10.0.0.0/16" }
+variable "availability_zones" { default = ["eu-west-1a", "eu-west-1b"] }
+```
+
+## Variables d'environnement Terraform
+
+```bash
+export TF_VAR_environment="dev"
+export TF_VAR_region="eu-west-1"
+export TF_VAR_db_password="your-secure-password"
+
+# Ou via fichier .tfvars (jamais commité)
+cat environments/dev/terraform.tfvars
+```
+
+## Remote State
+
+Le state Terraform est stocké à distance (S3 + DynamoDB lock) :
+
+```hcl
+# backend.tf
+terraform {
+  backend "s3" {
+    bucket         = "dreamscape-terraform-state"
+    key            = "dreamscape/terraform.tfstate"
+    region         = "eu-west-1"
+    dynamodb_table = "dreamscape-terraform-lock"
+    encrypt        = true
+  }
+}
+```
+
+## Workflow CI/CD
+
+Le pipeline `dreamscape-infra/.github/workflows/` intègre Terraform :
+1. `terraform fmt -check` — Vérification du format
+2. `terraform validate` — Validation de la syntaxe
+3. `terraform plan` — Plan sur les PRs
+4. `terraform apply` — Application automatique sur merge en `main` (prod)
+
+## Bonnes pratiques
+
+- Ne jamais stocker de secrets dans les fichiers `.tf` — utiliser les variables
+- Utiliser `terraform plan` avant chaque `apply`
+- Tags obligatoires sur toutes les ressources : `Project`, `Environment`, `ManagedBy=terraform`
+- Modules versionnés pour la réutilisabilité
+
+---
+
+*Voir `dreamscape-infra/README.md` pour l'architecture globale.*


### PR DESCRIPTION
## Summary

- Création `k8s/README.md` : structure base/overlays, kustomize, HPA, Big Pods bootstrap, commandes kubectl
- Création `terraform/README.md` : modules (k3s/databases/networking), workspaces, remote state S3
- Création `monitoring/README.md` : Prometheus, Grafana dashboards, Alertmanager, Loki, Promtail, règles d'alerte SLA
- Création `cicd/README.md` : pipeline 2-stages repository_dispatch, détection services modifiés, Big Pods CD, secrets requis

## Test plan

- [ ] Vérifier que la structure k8s documentée correspond aux fichiers présents dans `k8s/`
- [ ] Vérifier les noms de workflows GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)