### PR TITLE
fix(env): use relative URLs in staging env to avoid mixed content (DR-574)

### DIFF
--- a/docker/bigpods/experience-pod/.env.staging
+++ b/docker/bigpods/experience-pod/.env.staging
@@ -1,25 +1,28 @@
 # ===================================
 # Staging Environment - 79.72.27.180
-# Kubernetes with NGINX Ingress on port 80
+# Kubernetes with NGINX Ingress + HTTPS via nip.io
 # ===================================
 
 # Main API Gateway (via NGINX Ingress)
-VITE_API_BASE_URL=http://79.72.27.180/api
+VITE_API_BASE_URL=/api
+
+# Gateway URL for VR PIN generation (VRPinAccess component)
+VITE_GATEWAY_URL=
 
 # Auth Service (via Gateway)
-VITE_AUTH_SERVICE_URL=http://79.72.27.180/api
+VITE_AUTH_SERVICE_URL=/api
 
 # User Service (via Gateway)
-VITE_USER_SERVICE_API_URL=http://79.72.27.180/api
+VITE_USER_SERVICE_API_URL=/api
 
 # Voyage Service (via Gateway)
-VITE_VOYAGE_SERVICE_URL=http://79.72.27.180/api
+VITE_VOYAGE_SERVICE_URL=/api
 
 # Payment/Checkout Service (via Gateway)
-VITE_VOYAGE_API_URL=http://79.72.27.180
+VITE_VOYAGE_API_URL=
 
 # API Gateway
-VITE_API_GATEWAY_URL=http://79.72.27.180/api
+VITE_API_GATEWAY_URL=/api
 
 # External API Keys (add your actual keys)
 VITE_MAPBOX_TOKEN=your_mapbox_token_here


### PR DESCRIPTION
## Summary
- Use relative URLs (`/api`) instead of absolute `http://79.72.27.180/api` in `.env.staging`
- Prevents mixed content errors when the site is accessed via HTTPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)